### PR TITLE
Fetch & display min investment and spot price

### DIFF
--- a/src/components/Buy/BuyConfirmed.js
+++ b/src/components/Buy/BuyConfirmed.js
@@ -5,6 +5,7 @@ import ActiveButton from '../common/ActiveButton';
 import InactiveButton from '../common/InactiveButton';
 import { collateralType } from '../../config.json';
 import { useStores } from '../../contexts/storesContext';
+import { formatBalance } from '../../utils/token';
 
 const FormWrapper = styled.div`
     height: 200px;
@@ -87,12 +88,12 @@ const BuyConfirmed = observer((props) => {
             <InfoRow>
                 <FormInfoText>{infotext}</FormInfoText>
                 <div>
-                    {priceToBuy} {collateralType}
+                    {formatBalance(tradingStore.payAmount)} {collateralType}
                 </div>
             </InfoRow>
             <InfoRow>
-                <FormInfoText>Receive</FormInfoText>
-                <div>{buyAmount} DXD</div>
+                <FormInfoText>Pay</FormInfoText>
+                <div>{tradingStore.buyAmount} DXD</div>
             </InfoRow>
             <Confirmed>
                 Confirmed

--- a/src/components/Buy/BuyForm.js
+++ b/src/components/Buy/BuyForm.js
@@ -20,7 +20,7 @@ const BuyForm = observer((props) => {
         root: { tradingStore },
     } = useStores();
 
-    const infotext = 'Pay Amount';
+    const infotext = 'Tokens Issued';
     const count = tradingStore.buyingState;
 
     const Button = ({ active, children, onClick }) => {

--- a/src/components/Buy/BuyInput.js
+++ b/src/components/Buy/BuyInput.js
@@ -108,17 +108,6 @@ const BuyInput = observer((props) => {
         hasError = !(value > 0);
         const status = validateTokenValue(value);
 
-        /*
-            So, you need to make sure the PRICE is loaded and UPDATED
-            So we don't do it here, when get get a new PRICE - we check if the input is valid, and if it is, we refresh.
-
-            We also need to update WHEN the input is changed & valid - if there is a PRICE loaded, set it.
-
-            When a PRICE is loaded, set the result based on input
-            When a INPUT is added, set the results based on input
-
-         */
-
         if (status === ValidationStatus.VALID) {
             tradingStore.setPayAmountPending(true);
 

--- a/src/components/Buy/BuyInput.js
+++ b/src/components/Buy/BuyInput.js
@@ -119,8 +119,6 @@ const BuyInput = observer((props) => {
 
          */
 
-        console.log('status', status);
-
         if (status === ValidationStatus.VALID) {
             tradingStore.setPayAmountPending(true);
 
@@ -132,6 +130,9 @@ const BuyInput = observer((props) => {
             );
 
             tradingStore.handleBuyReturn(buyReturn);
+        } else {
+            tradingStore.setPayAmount(bnum(0));
+            tradingStore.setPrice(bnum(0));
         }
     };
 

--- a/src/components/Buy/BuySign.js
+++ b/src/components/Buy/BuySign.js
@@ -5,6 +5,7 @@ import ActiveButton from '../common/ActiveButton';
 import InactiveButton from '../common/InactiveButton';
 import { collateralType } from '../../config.json';
 import { useStores } from '../../contexts/storesContext';
+import { formatBalance } from '../../utils/token';
 
 const FormWrapper = styled.div`
     height: 200px;
@@ -78,12 +79,12 @@ const BuySign = observer((props) => {
             <InfoRow>
                 <FormInfoText>{infotext}</FormInfoText>
                 <div>
-                    {priceToBuy} {collateralType}
+                    {formatBalance(tradingStore.payAmount)} {collateralType}
                 </div>
             </InfoRow>
             <InfoRow>
-                <FormInfoText>Receive</FormInfoText>
-                <div>{buyAmount} DXD</div>
+                <FormInfoText>Pay</FormInfoText>
+                <div>{tradingStore.buyAmount} DXD</div>
             </InfoRow>
             <SignTransaction>
                 Sign Transaction...

--- a/src/components/Buy/BuyUnconfirmed.js
+++ b/src/components/Buy/BuyUnconfirmed.js
@@ -5,6 +5,7 @@ import ActiveButton from '../common/ActiveButton';
 import InactiveButton from '../common/InactiveButton';
 import { collateralType } from '../../config.json';
 import { useStores } from '../../contexts/storesContext';
+import { formatBalance } from '../../utils/token';
 
 const FormWrapper = styled.div`
     height: 200px;
@@ -77,12 +78,12 @@ const BuyUnconfirmed = observer((props) => {
             <InfoRow>
                 <FormInfoText>{infotext}</FormInfoText>
                 <div>
-                    {priceToBuy} {collateralType}
+                    {formatBalance(tradingStore.payAmount)} {collateralType}
                 </div>
             </InfoRow>
             <InfoRow>
-                <FormInfoText>Receive</FormInfoText>
-                <div>{buyAmount} DXD</div>
+                <FormInfoText>Pay</FormInfoText>
+                <div>{tradingStore.buyAmount} DXD</div>
             </InfoRow>
             <Unconfirmed>
                 Unconfirmed...

--- a/src/components/Web3ConnectStatus/index.jsx
+++ b/src/components/Web3ConnectStatus/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { UnsupportedChainIdError, useWeb3React } from '@web3-react/core';
+import { UnsupportedChainIdError } from '@web3-react/core';
 import { Activity } from 'react-feather';
 import { observer } from 'mobx-react';
 import { shortenAddress } from 'utils/address';
@@ -16,7 +16,6 @@ import Identicon from '../Identicon';
 import { useStores } from '../../contexts/storesContext';
 import Button from 'components/common/Button';
 import Web3PillBox from '../Web3PillBox';
-import { useActiveWeb3React } from 'provider/providerHooks';
 
 const Web3StatusGeneric = styled.button`
     ${({ theme }) => theme.flexRowNoWrap}
@@ -71,7 +70,12 @@ const Web3ConnectStatus = observer(() => {
     const {
         root: { modalStore, transactionStore, providerStore },
     } = useStores();
-    const { chainId, active, connector, error } = providerStore.getActiveWeb3React();
+    const {
+        chainId,
+        active,
+        connector,
+        error,
+    } = providerStore.getActiveWeb3React();
     const { account, chainId: injectedChainId } = providerStore.getWeb3React(
         web3ContextNames.injected
     );

--- a/src/components/common/Enable.js
+++ b/src/components/common/Enable.js
@@ -63,10 +63,14 @@ const Enable = observer(({ tokenType }) => {
         root: { providerStore, configStore, tokenStore },
     } = useStores();
 
-    const {account} = providerStore.getActiveWeb3React();
+    const { account } = providerStore.getActiveWeb3React();
     const tokenAddress = configStore.getTokenAddress(tokenType);
 
-    const hasMaxApproval = tokenStore.hasMaxApproval(tokenAddress, account, configStore.activeDatAddress);
+    const hasMaxApproval = tokenStore.hasMaxApproval(
+        tokenAddress,
+        account,
+        configStore.activeDatAddress
+    );
 
     return (
         <ContentWrapper>

--- a/src/provider/MetamaskConnector.ts
+++ b/src/provider/MetamaskConnector.ts
@@ -8,14 +8,14 @@ export class MetamaskConnector extends InjectedConnector {
     public async isAuthorized(): Promise<boolean> {
         // @ts-ignore
         if (!window.ethereum) {
-            return false
+            return false;
         }
 
         try {
             const provider = await this.getProvider();
-            return !!(provider && provider['selectedAddress']); }
-        catch {
-            return false
+            return !!(provider && provider['selectedAddress']);
+        } catch {
+            return false;
         }
     }
 }

--- a/src/provider/connectors.ts
+++ b/src/provider/connectors.ts
@@ -1,4 +1,3 @@
-import { InjectedConnector } from '@web3-react/injected-connector';
 import { NetworkConnector } from 'provider/NetworkConnector';
 import { MetamaskConnector } from './MetamaskConnector';
 

--- a/src/services/blockchainReader.ts
+++ b/src/services/blockchainReader.ts
@@ -1,0 +1,16 @@
+import { BigNumber } from '../utils/bignumber';
+
+export interface BlockchainData {
+    value: any;
+    blockNumber: number;
+}
+
+export interface BigNumberCached {
+    value: BigNumber;
+    blockNumber: number;
+}
+
+export interface StringCached {
+    value: string;
+    blockNumber: number;
+}

--- a/src/stores/BlockchainFetch.ts
+++ b/src/stores/BlockchainFetch.ts
@@ -68,10 +68,6 @@ export default class BlockchainFetchStore {
                                 );
                             })
                             .then(async () => {
-                                console.log(
-                                    'validateTokenValue(tradingStore.buyAmount)',
-                                    validateTokenValue(tradingStore.buyAmount)
-                                );
                                 if (
                                     validateTokenValue(
                                         tradingStore.buyAmount

--- a/src/stores/BlockchainFetch.ts
+++ b/src/stores/BlockchainFetch.ts
@@ -57,6 +57,22 @@ export default class BlockchainFetchStore {
                                 tradingStore.setRecentTrades(trades);
                             });
 
+                        datStore
+                            .fetchMinInvestment(configStore.activeDatAddress)
+                            .then((minInvestment) => {
+                                datStore.setMinInvestment(
+                                    configStore.activeDatAddress,
+                                    minInvestment
+                                );
+                            })
+                            .then(() => {
+                                datStore
+                                    .fetchPrice(configStore.activeDatAddress)
+                                    .then((price) => {
+                                        tradingStore.setPrice(price);
+                                    });
+                            });
+
                         // Get user-specific blockchain data
                         if (account) {
                             tokenStore.fetchTokenBalances(web3React, account, [

--- a/src/stores/Provider.ts
+++ b/src/stores/Provider.ts
@@ -62,6 +62,14 @@ export default class ProviderStore {
         this.chainData = { currentBlockNumber: -1 } as ChainData;
     }
 
+    isFresh(blockNumber: number): boolean {
+        return blockNumber === this.getCurrentBlockNumber();
+    }
+
+    isFresher(newBlockNumber: number, oldBlockNumber: number): boolean {
+        return newBlockNumber > oldBlockNumber;
+    }
+
     isBlockStale(blockNumber: number) {
         return blockNumber < this.chainData.currentBlockNumber;
     }

--- a/src/stores/Token.ts
+++ b/src/stores/Token.ts
@@ -14,7 +14,6 @@ import {
 } from './actions/fetch';
 import { Web3ReactContextInterface } from '@web3-react/core/dist/types';
 import { BigNumberMap } from '../types';
-import { ActionResponse } from './actions/actions';
 import { PromiEvent } from 'web3-core';
 
 export interface TokenBalance {

--- a/src/stores/TradingForm.ts
+++ b/src/stores/TradingForm.ts
@@ -2,6 +2,8 @@ import { action, observable } from 'mobx';
 import { buyStartState } from '../config.json';
 import RootStore from './Root';
 import { TradeEvent } from './datStore';
+import { BigNumber } from '../utils/bignumber';
+import { bnum } from '../utils/helpers';
 
 const ConfirmationFlags = {
     ENABLE_TKN: 'enable_TKN',
@@ -19,7 +21,7 @@ export enum TransactionState {
 
 class TradingFormStore {
     @observable reserveBalance = '';
-    @observable price = 0;
+    @observable price: BigNumber = bnum(0);
 
     @observable enableTKNState = buyStartState;
     @observable buyingState = TransactionState.NONE;
@@ -43,9 +45,8 @@ class TradingFormStore {
     }
 
     // setPrice()
-    async setPrice() {
-        // const price = await this.getPriceToBuy('1');
-        this.price = 0;
+    setPrice(price: BigNumber) {
+        this.price = price;
     }
 
     // setBuyAmount()

--- a/src/stores/TradingForm.ts
+++ b/src/stores/TradingForm.ts
@@ -1,9 +1,10 @@
 import { action, observable } from 'mobx';
 import { buyStartState } from '../config.json';
 import RootStore from './Root';
-import { TradeEvent } from './datStore';
+import { BuyReturnCached, TradeEvent } from './datStore';
 import { BigNumber } from '../utils/bignumber';
 import { bnum } from '../utils/helpers';
+import { denormalizeBalance } from '../utils/token';
 
 const ConfirmationFlags = {
     ENABLE_TKN: 'enable_TKN',
@@ -25,8 +26,8 @@ class TradingFormStore {
 
     @observable enableTKNState = buyStartState;
     @observable buyingState = TransactionState.NONE;
-    @observable buyAmount = 0;
-    @observable priceToBuy = 0;
+    @observable buyAmount = '';
+    @observable priceToBuy: BigNumber = bnum(0);
 
     @observable enableDXDState = TransactionState.NONE;
     @observable sellingState = TransactionState.NONE;
@@ -36,6 +37,9 @@ class TradingFormStore {
     @observable bondedTokenBalance = 0;
     @observable bondedTokenPrice = 0;
 
+    @observable payAmount: BigNumber = bnum(0);
+    @observable payAmountPending = false;
+
     @observable recentTrades = [];
     @observable recentTradesSet = false;
     rootStore: RootStore;
@@ -44,22 +48,40 @@ class TradingFormStore {
         this.rootStore = rootStore;
     }
 
+    setPayAmount(amount: BigNumber) {
+        this.payAmount = amount;
+    }
+
+    setPayAmountPending(isPending: boolean) {
+        this.payAmountPending = isPending;
+    }
+
     // setPrice()
     setPrice(price: BigNumber) {
         this.price = price;
     }
 
+    handleBuyReturn(buyReturn: BuyReturnCached) {
+        const weiValue = denormalizeBalance(this.buyAmount);
+
+        const inputValueFresh = buyReturn.value.totalPaid.eq(weiValue);
+
+        if (
+            this.rootStore.providerStore.isFresh(buyReturn.blockNumber) &&
+            inputValueFresh
+        )
+            this.setPrice(buyReturn.value.pricePerToken);
+        this.setPayAmount(buyReturn.value.tokensIssued);
+        this.setPayAmountPending(false);
+    }
+
     // setBuyAmount()
     setBuyAmount(buyAmount) {
-        // TODO: Async get the price to buy
-        // this.setPriceToBuy(buyAmount);
         this.buyAmount = buyAmount;
     }
 
     // setSellAmount()
     setSellAmount(sellAmount) {
-        // TODO: Async get the reward to sell
-        // this.setRewardForSell(sellAmount);
         this.sellAmount = sellAmount;
     }
 

--- a/src/stores/datStore.ts
+++ b/src/stores/datStore.ts
@@ -31,13 +31,13 @@ export interface SellEvent {
     hash: string;
 }
 
-interface DatParams {
+interface DatInfo {
     minInvestment?: BigNumber;
     currentPrice?: BigNumberCached;
 }
 
-interface DatParamsMap {
-    [index: string]: DatParams;
+interface DatInfoMap {
+    [index: string]: DatInfo;
 }
 
 export interface BuyReturnCached {
@@ -65,12 +65,12 @@ export interface SellReturn {
 export type TradeEvent = BuyEvent | SellEvent;
 
 export default class DatStore {
-    @observable datParams: DatParamsMap;
+    @observable datParams: DatInfoMap;
     rootStore: RootStore;
 
     constructor(rootStore) {
         this.rootStore = rootStore;
-        this.datParams = {} as DatParamsMap;
+        this.datParams = {} as DatInfoMap;
     }
 
     /*


### PR DESCRIPTION
Fix #86 #72

Fetches current price and tokens issued based on user input and display in view.

Note: We don't use the spot price, we get the REAL price per token based on current input.


Note: @jpkcambridge I also have the spot price function, which uses the cOrg-defined 'minimum investment', which is the minimum a user can buy. 

So "how much would it cost to buy the minimum possible right now, per unit?"

![image](https://user-images.githubusercontent.com/5606917/78201822-92650d80-7460-11ea-82be-01e03ef5fe67.png)
