### PR TITLE
Remove isChainIdSupported from log in Web3ConnectStatus component

### DIFF
--- a/src/components/Web3ConnectStatus/index.jsx
+++ b/src/components/Web3ConnectStatus/index.jsx
@@ -121,7 +121,7 @@ const Web3ConnectStatus = observer((props) => {
     function getWeb3Status() {
         console.log('[GetWeb3Status]', {
             account,
-            isChainIdSupported: isChainIdSupported(injectedChainId),
+            injectedChainId: injectedChainId,
             error,
         });
         // Wrong network


### PR DESCRIPTION
This log executes that function that cause develop to break when metamask is not connected.