### PR TITLE
Add ropsten and mainnet testing deployments

### DIFF
--- a/.openzeppelin/mainnet.json
+++ b/.openzeppelin/mainnet.json
@@ -1,0 +1,342 @@
+{
+  "contracts": {
+    "DecentralizedAutonomousTrust": {
+      "address": "0xD98034E78C052C9B975E3D1C3d274e4ab54A8092",
+      "constructorCode": "6080604052613eb5806100136000396000f3fe",
+      "bodyBytecodeHash": "9ed37b5bf8f340ca2f52c23ccf78d4dc4419e64083ce2288b46f122f252e138d",
+      "localBytecodeHash": "11683e645fe7058618dba91adadedb83bd6bbe2bad96121bcf889c3b01a3ad2e",
+      "deployedBytecodeHash": "11683e645fe7058618dba91adadedb83bd6bbe2bad96121bcf889c3b01a3ad2e",
+      "types": {
+        "t_bool": {
+          "id": "t_bool",
+          "kind": "elementary",
+          "label": "bool"
+        },
+        "t_uint256": {
+          "id": "t_uint256",
+          "kind": "elementary",
+          "label": "uint256"
+        },
+        "t_array:50<t_uint256>": {
+          "id": "t_array:50<t_uint256>",
+          "valueType": "t_uint256",
+          "length": "50",
+          "kind": "array",
+          "label": "uint256[50]"
+        },
+        "t_mapping<t_uint256>": {
+          "id": "t_mapping<t_uint256>",
+          "valueType": "t_uint256",
+          "label": "mapping(key => uint256)",
+          "kind": "mapping"
+        },
+        "t_string": {
+          "id": "t_string",
+          "kind": "elementary",
+          "label": "string"
+        },
+        "t_uint8": {
+          "id": "t_uint8",
+          "kind": "elementary",
+          "label": "uint8"
+        },
+        "t_address": {
+          "id": "t_address",
+          "kind": "elementary",
+          "label": "address"
+        },
+        "t_address_payable": {
+          "id": "t_address_payable",
+          "kind": "elementary",
+          "label": "address payable"
+        },
+        "t_bytes32": {
+          "id": "t_bytes32",
+          "kind": "elementary",
+          "label": "bytes32"
+        }
+      },
+      "storage": [
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "initialized",
+          "astId": 5875,
+          "type": "t_bool",
+          "src": "757:24:19"
+        },
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "initializing",
+          "astId": 5877,
+          "type": "t_bool",
+          "src": "876:25:19"
+        },
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "______gap",
+          "astId": 5939,
+          "type": "t_array:50<t_uint256>",
+          "src": "1982:29:19"
+        },
+        {
+          "contract": "ERC20",
+          "path": "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol",
+          "label": "_balances",
+          "astId": 5047,
+          "type": "t_mapping<t_uint256>",
+          "src": "1418:46:14"
+        },
+        {
+          "contract": "ERC20",
+          "path": "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol",
+          "label": "_allowances",
+          "astId": 5053,
+          "type": "t_mapping<t_uint256>",
+          "src": "1471:69:14"
+        },
+        {
+          "contract": "ERC20",
+          "path": "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol",
+          "label": "_totalSupply",
+          "astId": 5055,
+          "type": "t_uint256",
+          "src": "1547:28:14"
+        },
+        {
+          "contract": "ERC20",
+          "path": "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol",
+          "label": "______gap",
+          "astId": 5439,
+          "type": "t_array:50<t_uint256>",
+          "src": "8172:29:14"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "_name",
+          "astId": 5450,
+          "type": "t_string",
+          "src": "224:20:15"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "_symbol",
+          "astId": 5452,
+          "type": "t_string",
+          "src": "250:22:15"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "_decimals",
+          "astId": 5454,
+          "type": "t_uint8",
+          "src": "278:23:15"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "______gap",
+          "astId": 5506,
+          "type": "t_array:50<t_uint256>",
+          "src": "1654:29:15"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "whitelist",
+          "astId": 118,
+          "type": "t_address",
+          "src": "3175:27:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "burnedSupply",
+          "astId": 120,
+          "type": "t_uint256",
+          "src": "3318:24:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "autoBurn",
+          "astId": 122,
+          "type": "t_bool",
+          "src": "3604:20:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "beneficiary",
+          "astId": 124,
+          "type": "t_address_payable",
+          "src": "3767:34:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "buySlopeNum",
+          "astId": 126,
+          "type": "t_uint256",
+          "src": "3997:23:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "buySlopeDen",
+          "astId": 128,
+          "type": "t_uint256",
+          "src": "4218:23:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "control",
+          "astId": 130,
+          "type": "t_address",
+          "src": "4322:22:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "currency",
+          "astId": 132,
+          "type": "t_address",
+          "src": "4470:22:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "feeCollector",
+          "astId": 134,
+          "type": "t_address_payable",
+          "src": "4544:35:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "feeBasisPoints",
+          "astId": 136,
+          "type": "t_uint256",
+          "src": "4681:26:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "initGoal",
+          "astId": 138,
+          "type": "t_uint256",
+          "src": "4894:20:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "initInvestors",
+          "astId": 142,
+          "type": "t_mapping<t_uint256>",
+          "src": "5142:45:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "initReserve",
+          "astId": 144,
+          "type": "t_uint256",
+          "src": "5678:23:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "investmentReserveBasisPoints",
+          "astId": 146,
+          "type": "t_uint256",
+          "src": "5900:40:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "openUntilAtLeast",
+          "astId": 148,
+          "type": "t_uint256",
+          "src": "6219:28:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "minInvestment",
+          "astId": 150,
+          "type": "t_uint256",
+          "src": "6320:25:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "revenueCommitmentBasisPoints",
+          "astId": 152,
+          "type": "t_uint256",
+          "src": "6568:40:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "state",
+          "astId": 154,
+          "type": "t_uint256",
+          "src": "6724:17:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "nonces",
+          "astId": 161,
+          "type": "t_mapping<t_uint256>",
+          "src": "6914:39:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "DOMAIN_SEPARATOR",
+          "astId": 163,
+          "type": "t_bytes32",
+          "src": "6957:31:0"
+        }
+      ],
+      "warnings": {
+        "hasConstructor": false,
+        "hasSelfDestruct": false,
+        "hasDelegateCall": false,
+        "hasInitialValuesInDeclarations": false,
+        "uninitializedBaseContracts": []
+      }
+    }
+  },
+  "solidityLibs": {},
+  "proxies": {
+    "BC-DAPP/DecentralizedAutonomousTrust": [
+      {
+        "address": "0x7B5a561d2Fa4536086737c2B00F364cB68201dCA",
+        "version": "0.1.0",
+        "implementation": "0xD98034E78C052C9B975E3D1C3d274e4ab54A8092",
+        "admin": "0xa607Dc6D35C96f0783b324fC34D5ED1D14b45d45",
+        "kind": "Upgradeable"
+      }
+    ],
+    "BC-DAPP/Multicall": [
+      {
+        "address": "0x742121cD0BB9784c1f17f25B8da1bF3445b93ED4",
+        "kind": "NonProxy",
+        "bytecodeHash": "daa7a021eecb7d6e3a847506aa7589e5a9bbdabd6fe91c538a1d9fb37b7fd577"
+      }
+    ]
+  },
+  "manifestVersion": "2.2",
+  "version": "0.1.0",
+  "proxyAdmin": {
+    "address": "0xa607Dc6D35C96f0783b324fC34D5ED1D14b45d45"
+  }
+}

--- a/.openzeppelin/project.json
+++ b/.openzeppelin/project.json
@@ -18,7 +18,7 @@
       "enabled": false
     },
     "manager": "truffle",
-    "artifactsDir": "build/contracts",
+    "artifactsDir": "contracts/build",
     "contractsDir": "contracts"
   },
   "telemetryOptIn": true

--- a/.openzeppelin/ropsten.json
+++ b/.openzeppelin/ropsten.json
@@ -1,0 +1,326 @@
+{
+  "contracts": {
+    "DecentralizedAutonomousTrust": {
+      "address": "0x64E15dFA18DDE38F4D4e27EFc00F4BCFCCe8144a",
+      "constructorCode": "6080604052613eb5806100136000396000f3fe",
+      "bodyBytecodeHash": "9ed37b5bf8f340ca2f52c23ccf78d4dc4419e64083ce2288b46f122f252e138d",
+      "localBytecodeHash": "11683e645fe7058618dba91adadedb83bd6bbe2bad96121bcf889c3b01a3ad2e",
+      "deployedBytecodeHash": "11683e645fe7058618dba91adadedb83bd6bbe2bad96121bcf889c3b01a3ad2e",
+      "types": {
+        "t_bool": {
+          "id": "t_bool",
+          "kind": "elementary",
+          "label": "bool"
+        },
+        "t_uint256": {
+          "id": "t_uint256",
+          "kind": "elementary",
+          "label": "uint256"
+        },
+        "t_array:50<t_uint256>": {
+          "id": "t_array:50<t_uint256>",
+          "valueType": "t_uint256",
+          "length": "50",
+          "kind": "array",
+          "label": "uint256[50]"
+        },
+        "t_mapping<t_uint256>": {
+          "id": "t_mapping<t_uint256>",
+          "valueType": "t_uint256",
+          "label": "mapping(key => uint256)",
+          "kind": "mapping"
+        },
+        "t_string": {
+          "id": "t_string",
+          "kind": "elementary",
+          "label": "string"
+        },
+        "t_uint8": {
+          "id": "t_uint8",
+          "kind": "elementary",
+          "label": "uint8"
+        },
+        "t_address": {
+          "id": "t_address",
+          "kind": "elementary",
+          "label": "address"
+        },
+        "t_address_payable": {
+          "id": "t_address_payable",
+          "kind": "elementary",
+          "label": "address payable"
+        },
+        "t_bytes32": {
+          "id": "t_bytes32",
+          "kind": "elementary",
+          "label": "bytes32"
+        }
+      },
+      "storage": [
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "initialized",
+          "astId": 5875,
+          "type": "t_bool",
+          "src": "757:24:19"
+        },
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "initializing",
+          "astId": 5877,
+          "type": "t_bool",
+          "src": "876:25:19"
+        },
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "______gap",
+          "astId": 5939,
+          "type": "t_array:50<t_uint256>",
+          "src": "1982:29:19"
+        },
+        {
+          "contract": "ERC20",
+          "path": "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol",
+          "label": "_balances",
+          "astId": 5047,
+          "type": "t_mapping<t_uint256>",
+          "src": "1418:46:14"
+        },
+        {
+          "contract": "ERC20",
+          "path": "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol",
+          "label": "_allowances",
+          "astId": 5053,
+          "type": "t_mapping<t_uint256>",
+          "src": "1471:69:14"
+        },
+        {
+          "contract": "ERC20",
+          "path": "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol",
+          "label": "_totalSupply",
+          "astId": 5055,
+          "type": "t_uint256",
+          "src": "1547:28:14"
+        },
+        {
+          "contract": "ERC20",
+          "path": "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol",
+          "label": "______gap",
+          "astId": 5439,
+          "type": "t_array:50<t_uint256>",
+          "src": "8172:29:14"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "_name",
+          "astId": 5450,
+          "type": "t_string",
+          "src": "224:20:15"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "_symbol",
+          "astId": 5452,
+          "type": "t_string",
+          "src": "250:22:15"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "_decimals",
+          "astId": 5454,
+          "type": "t_uint8",
+          "src": "278:23:15"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "______gap",
+          "astId": 5506,
+          "type": "t_array:50<t_uint256>",
+          "src": "1654:29:15"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "whitelist",
+          "astId": 118,
+          "type": "t_address",
+          "src": "3175:27:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "burnedSupply",
+          "astId": 120,
+          "type": "t_uint256",
+          "src": "3318:24:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "autoBurn",
+          "astId": 122,
+          "type": "t_bool",
+          "src": "3604:20:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "beneficiary",
+          "astId": 124,
+          "type": "t_address_payable",
+          "src": "3767:34:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "buySlopeNum",
+          "astId": 126,
+          "type": "t_uint256",
+          "src": "3997:23:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "buySlopeDen",
+          "astId": 128,
+          "type": "t_uint256",
+          "src": "4218:23:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "control",
+          "astId": 130,
+          "type": "t_address",
+          "src": "4322:22:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "currency",
+          "astId": 132,
+          "type": "t_address",
+          "src": "4470:22:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "feeCollector",
+          "astId": 134,
+          "type": "t_address_payable",
+          "src": "4544:35:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "feeBasisPoints",
+          "astId": 136,
+          "type": "t_uint256",
+          "src": "4681:26:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "initGoal",
+          "astId": 138,
+          "type": "t_uint256",
+          "src": "4894:20:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "initInvestors",
+          "astId": 142,
+          "type": "t_mapping<t_uint256>",
+          "src": "5142:45:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "initReserve",
+          "astId": 144,
+          "type": "t_uint256",
+          "src": "5678:23:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "investmentReserveBasisPoints",
+          "astId": 146,
+          "type": "t_uint256",
+          "src": "5900:40:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "openUntilAtLeast",
+          "astId": 148,
+          "type": "t_uint256",
+          "src": "6219:28:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "minInvestment",
+          "astId": 150,
+          "type": "t_uint256",
+          "src": "6320:25:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "revenueCommitmentBasisPoints",
+          "astId": 152,
+          "type": "t_uint256",
+          "src": "6568:40:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "state",
+          "astId": 154,
+          "type": "t_uint256",
+          "src": "6724:17:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "nonces",
+          "astId": 161,
+          "type": "t_mapping<t_uint256>",
+          "src": "6914:39:0"
+        },
+        {
+          "contract": "DecentralizedAutonomousTrust",
+          "path": "contracts/DecentralizedAutonomousTrust.sol",
+          "label": "DOMAIN_SEPARATOR",
+          "astId": 163,
+          "type": "t_bytes32",
+          "src": "6957:31:0"
+        }
+      ],
+      "warnings": {
+        "hasConstructor": false,
+        "hasSelfDestruct": false,
+        "hasDelegateCall": false,
+        "hasInitialValuesInDeclarations": false,
+        "uninitializedBaseContracts": []
+      }
+    }
+  },
+  "solidityLibs": {},
+  "proxies": {
+  },
+  "manifestVersion": "2.2",
+  "version": "0.1.0",
+  "proxyAdmin": {
+    "address": "0x70cC43912fAD6842E9dE9dfb1e8AaF92EDbBc40C"
+  }
+}

--- a/scripts/loadDeployments.js
+++ b/scripts/loadDeployments.js
@@ -50,4 +50,8 @@ async function loadDeployment(network) {
   console.log('Deployment configuration loaded for network '+network);
 } 
 
-loadDeployment('kovan');
+async function main() {
+  await loadDeployment(process.env.REACT_APP_ETH_NETWORK);
+};
+
+main();

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -3,5 +3,6 @@
 npx truffle version
 npx truffle compile && rm -rf contracts/build && mv build/contracts contracts/build/
 node scripts/copyContracts.js
+node scripts/loadDeployments.js
 sleep 1
 FORCE_COLOR=true node scripts/start.js | cat

--- a/src/config/toDeploy.json
+++ b/src/config/toDeploy.json
@@ -1,7 +1,7 @@
 {
     "DATinfo": {
         "collateralType": "ETH",
-        "name": "dxDAO Token",
+        "name": "Dxdao Token",
         "symbol": "DXD",
         "currency": "0x0000000000000000000000000000000000000000",
         "initReserve": "85000000000000000000000",
@@ -11,5 +11,25 @@
         "investmentReserveBasisPoints": "1000",
         "revenueCommitmentBasisPoints": "1000",
         "minInvestment": "100000000000000000"
+    },
+    "DATinfoMainnet": {
+        "collateralType": "ETH",
+        "name": "Dxdao Token",
+        "symbol": "DXD",
+        "currency": "0x0000000000000000000000000000000000000000",
+        "whitelistAddress": "0x0000000000000000000000000000000000000000",
+        "initReserve": "100000000000000000000000",
+        "initGoal": "4800000000000000000000",
+        "buySlopeNum": "1",
+        "buySlopeDen": "36000000000000000000000",
+        "investmentReserveBasisPoints": "1000",
+        "revenueCommitmentBasisPoints": "1000",
+        "minInvestment": "1000000000000000",
+        "beneficiary": "0x519b70055af55A007110B4Ff99b0eA33071c720a",
+        "control": "0x519b70055af55A007110B4Ff99b0eA33071c720a",
+        "feeCollector": "0x519b70055af55A007110B4Ff99b0eA33071c720a",
+        "feeBasisPoints": "0",
+        "autoBurn": "true",
+        "openUntilAtLeast": "0"
     }
 }

--- a/truffle.js
+++ b/truffle.js
@@ -41,7 +41,7 @@ module.exports = {
         return new HDWalletProvider(mnemonic, `https://ropsten.infura.io/v3/${infuraApiKey}`)	
       },	
       network_id: '3',	
-      gas: 9000000,	
+      gas: 8000000,	
       gasPrice: 10000000000 //10 Gwei	
     },	
     kovan: {	


### PR DESCRIPTION
- Adds ropsten deployment with same values as kovan, you can see them in the `src/config/toDeploy.json` file under the DATinfo key.
- Adds mainnet deployment with similar values to the ones that will be used by the [approved config by DXDao](https://daotalk.org/t/configuration-template-for-fundraising-decentralized-application/1250), but with a single account as controller, beneficiary and fee collector, and 0.0001 as min ETH investment you can see them in the `src/config/toDeploy.json` file under the DATinfoMainnet key.