### PR TITLE
Multiple network support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,8 @@
-
 # React development variables
 REACT_APP_MARKET_API_URL=
 REACT_APP_KEY_MNEMONIC=""
 REACT_APP_KEY_INFURA_API_KEY=""
-REACT_APP_ETH_NETWORKS="mainnet,kovan"
+REACT_APP_ETH_NETWORKS=mainnet,kovan
 REACT_APP_GIT_SHA=""
 
 # Override network rpc urls here

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+
+# React development variables
+REACT_APP_MARKET_API_URL=
+REACT_APP_KEY_MNEMONIC=""
+REACT_APP_KEY_INFURA_API_KEY=""
+REACT_APP_ETH_NETWORKS="mainnet,kovan"
+REACT_APP_GIT_SHA=""
+
+# Override network rpc urls here
+# REACT_APP_SUPPORTED_NETWORK_1="https://mainnet.eth.cloud.ava.do"
+# REACT_APP_SUPPORTED_NETWORK_3=""
+# REACT_APP_SUPPORTED_NETWORK_4=""
+# REACT_APP_SUPPORTED_NETWORK_42=""
+# REACT_APP_SUPPORTED_NETWORK_66=""
+
+# NodeJS environment to use, can be development or production
+NODE_ENV="development"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -47,4 +47,4 @@ npx truffle compile && rm -rf contracts/build && mv build/contracts contracts/bu
 node scripts/copyContracts.js
 node scripts/deploy.js -- --network develop &
 sleep 3
-FORCE_COLOR=true REACT_APP_ETH_NETWORK=develop node scripts/start.js | cat
+FORCE_COLOR=true REACT_APP_ETH_NETWORKS="develop,mainnet,kovan" node scripts/start.js | cat

--- a/scripts/loadDeployments.js
+++ b/scripts/loadDeployments.js
@@ -51,7 +51,10 @@ async function loadDeployment(network) {
 } 
 
 async function main() {
-  await loadDeployment(process.env.REACT_APP_ETH_NETWORK);
+  process.env.REACT_APP_ETH_NETWORKS.split(',').forEach(async (network) => {
+    if (network == 'mainnnet' || network == 'ropsten' || network == 'kovan')
+      await loadDeployment(network);
+  });
 };
 
 main();

--- a/scripts/loadDeployments.js
+++ b/scripts/loadDeployments.js
@@ -52,7 +52,7 @@ async function loadDeployment(network) {
 
 async function main() {
   process.env.REACT_APP_ETH_NETWORKS.split(',').forEach(async (network) => {
-    if (network == 'mainnnet' || network == 'ropsten' || network == 'kovan')
+    if (network == 'mainnet' || network == 'ropsten' || network == 'kovan')
       await loadDeployment(network);
   });
 };

--- a/src/components/BondingCurveChart.tsx
+++ b/src/components/BondingCurveChart.tsx
@@ -76,14 +76,16 @@ const BondingCurveChart = observer(({}) => {
     const {
         root: { tradingStore, tokenStore, configStore, datStore },
     } = useStores();
+    
+    const activeDATAddress = configStore.getDXDTokenAddress()
 
     const staticParamsLoaded = datStore.areAllStaticParamsLoaded(
-        configStore.activeDatAddress
+        activeDATAddress
     );
-    const totalSupply = tokenStore.getTotalSupply(configStore.activeDatAddress);
-    const datState = datStore.getState(configStore.activeDatAddress);
+    const totalSupply = tokenStore.getTotalSupply(activeDATAddress);
+    const datState = datStore.getState(activeDATAddress);
     const reserveBalance = datStore.getReserveBalance(
-        configStore.activeDatAddress
+        activeDATAddress
     );
 
     const requiredDataLoaded =
@@ -99,10 +101,10 @@ const BondingCurveChart = observer(({}) => {
         kickstarterPrice;
 
     if (requiredDataLoaded) {
-        buySlopeNum = datStore.getBuySlopeNum(configStore.activeDatAddress);
-        buySlopeDen = datStore.getBuySlopeDen(configStore.activeDatAddress);
-        initGoal = datStore.getInitGoal(configStore.activeDatAddress);
-        initReserve = datStore.getInitReserve(configStore.activeDatAddress);
+        buySlopeNum = datStore.getBuySlopeNum(activeDATAddress);
+        buySlopeDen = datStore.getBuySlopeDen(activeDATAddress);
+        initGoal = datStore.getInitGoal(activeDATAddress);
+        initReserve = datStore.getInitReserve(activeDATAddress);
 
         cOrg = new COrgSim({
             buySlopeNum,
@@ -234,13 +236,13 @@ const BondingCurveChart = observer(({}) => {
 
         const hasInitGoal = initGoal.gt(0);
         const hasExceededInitGoal = datStore.isRunPhase(
-            configStore.activeDatAddress
+            activeDATAddress
         );
         const futureSupplyExceedsInitGoal =
             hasActiveInput && futureSupply.gt(initGoal);
 
         console.debug('chartParams', {
-            datParams: datStore.datParams[configStore.activeDatAddress],
+            datParams: datStore.datParams[activeDATAddress],
             initReserve: initReserve.toString(),
             initGoal: initGoal.toString(),
             buySlopeNum: buySlopeNum.toString(),
@@ -391,9 +393,9 @@ const BondingCurveChart = observer(({}) => {
      */
 
     const renderChartHeader = () => {
-        if (datStore.isInitPhase(configStore.activeDatAddress)) {
+        if (datStore.isInitPhase(activeDATAddress)) {
             return renderInitPhaseChartHeader();
-        } else if (datStore.isRunPhase(configStore.activeDatAddress)) {
+        } else if (datStore.isRunPhase(activeDATAddress)) {
             return renderRunPhaseChartHeader();
         } else {
             return <React.Fragment />;

--- a/src/components/Buy/BuyInput.js
+++ b/src/components/Buy/BuyInput.js
@@ -91,7 +91,7 @@ const BuyInput = observer((props) => {
     const price = (buyInputStatus == "") ? tradingStore.formatNumber(0) : tradingStore.formatPrice();
     let disconnectedError = (tradingStore.buyAmount > 0) ? (account == null) ? true : false : false;
     let txFailedError = (tradingStore.buyingState == 5) && (buyInputStatus == "") ? true : false;
-    const datState = datStore.getState(configStore.activeDatAddress);
+    const datState = datStore.getState(configStore.getDXDTokenAddress());
     const requiredDataLoaded = datState !== undefined;
     
     if (buyInputStatus == "" && tradingStore.payAmount != 0) {
@@ -119,7 +119,7 @@ const BuyInput = observer((props) => {
 
         const buyInputStatusFetch = validateTokenValue(value, {
           minValue: normalizeBalance(
-              datStore.getMinInvestment(configStore.activeDatAddress)
+              datStore.getMinInvestment(configStore.getDXDTokenAddress())
           ),
           maxBalance: (account) ? normalizeBalance(ETHBalance) : null,
         });
@@ -128,7 +128,7 @@ const BuyInput = observer((props) => {
         if (buyInputStatusFetch === ValidationStatus.VALID) {
             tradingStore.setBuyAmount(value);
             const buyReturn = await datStore.fetchBuyReturn(
-              configStore.activeDatAddress,
+              configStore.getDXDTokenAddress(),
               denormalizeBalance(value)
             );
             tradingStore.handleBuyReturn(buyReturn);
@@ -181,7 +181,7 @@ const BuyInput = observer((props) => {
                     tradingStore.buyingState = TransactionState.SIGNING_TX;
                     datStore
                         .buy(
-                            configStore.activeDatAddress,
+                            configStore.getDXDTokenAddress(),
                             account,
                             denormalizeBalance(str(tradingStore.buyAmount)),
                             bnum(1)

--- a/src/components/BuySell.js
+++ b/src/components/BuySell.js
@@ -36,7 +36,9 @@ const BuySell = observer(() => {
     const [currentTab, setCurrentTab] = useState(0);
     const incrementTKN = tradingStore.enableTKNState;
     const incrementDXD = tradingStore.enableDXDState;
-    const hasMaxDXDApproval = account ? tokenStore.hasMaxApproval(configStore.getDXDTokenAddress(), account, configStore.activeDatAddress) : false;
+    const hasMaxDXDApproval = account ? tokenStore.hasMaxApproval(
+      configStore.getDXDTokenAddress(), account, configStore.getDXDTokenAddress()
+    ) : false;
     const isAccountDataLoaded = tradingStore.isDataLoaded(account);
 
     const CurrentForm = ({ currentTab, incrementTKN, incrementDXD }) => {

--- a/src/components/BuySellTabs.js
+++ b/src/components/BuySellTabs.js
@@ -35,7 +35,7 @@ const BuySellTabs = observer(({currentTab, setCurrentTab}) => {
     const {
         root: { configStore, datStore },
     } = useStores();
-	const sellText = datStore.isInitPhase(configStore.activeDatAddress) ? "Withdraw" : "Sell";
+	const sellText = datStore.isInitPhase(configStore.getDXDTokenAddress()) ? "Withdraw" : "Sell";
 
     const TabButton = ({ currentTab, tabType, left, children }) => {
         if (currentTab === tabType) {

--- a/src/components/Enable/Enable.js
+++ b/src/components/Enable/Enable.js
@@ -64,7 +64,7 @@ const Enable = observer(({ tokenType }) => {
     const hasMaxApproval = tokenStore.hasMaxApproval(
         tokenAddress,
         account,
-        configStore.activeDatAddress
+        configStore.getDXDTokenAddress()
     );
 
     return (
@@ -81,7 +81,7 @@ const Enable = observer(({ tokenType }) => {
                     tokenStore.approveMax(
                         providerStore.getActiveWeb3React(),
                         tokenAddress,
-                        configStore.activeDatAddress
+                        configStore.getDXDTokenAddress()
                     ).on(TXEvents.TX_HASH, (hash) => {
                         tradingStore.setEnableDXDState(TransactionState.UNCONFIRMED);
                     })

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { contracts } from '../config/contracts';
-import { ETH_NETWORK } from '../provider/connectors';
+import { DEFAULT_ETH_NETWORK } from '../provider/connectors';
 
 const FooterWrapper = styled.div`
     display: flex;
@@ -75,9 +75,9 @@ const Footer = ({}) => {
                     <a
                         href={
                             'https://' +
-                            ETH_NETWORK +
+                            DEFAULT_ETH_NETWORK +
                             '.etherscan.io/address/' +
-                            contracts[ETH_NETWORK].DAT
+                            contracts[DEFAULT_ETH_NETWORK].DAT
                         }
                         target="#"
                     >
@@ -89,9 +89,9 @@ const Footer = ({}) => {
                     <a
                         href={
                             'https://' +
-                            ETH_NETWORK +
+                            DEFAULT_ETH_NETWORK +
                             '.etherscan.io/address/' +
-                            contracts[ETH_NETWORK].DATinfo.implementationAddress
+                            contracts[DEFAULT_ETH_NETWORK].DATinfo.implementationAddress
                         }
                         target="#"
                     >

--- a/src/components/Sell/SellConfirmed.js
+++ b/src/components/Sell/SellConfirmed.js
@@ -56,7 +56,7 @@ const SellConfirmed = observer((props) => {
     const price = tradingStore.formatSellPrice();
     const rewardForSell = tradingStore.rewardForSell;
     const sellAmount = tradingStore.formatSellAmount();
-    const sellText = datStore.isInitPhase(configStore.activeDatAddress) ? "Withdraw" : "Sell";
+    const sellText = datStore.isInitPhase(configStore.getDXDTokenAddress()) ? "Withdraw" : "Sell";
 
     const Button = ({ active, children, onClick }) => {
         if (active === true) {

--- a/src/components/Sell/SellInput.js
+++ b/src/components/Sell/SellInput.js
@@ -89,7 +89,7 @@ const SellInput = observer((props) => {
     const price = (sellInputStatus == "") ? tradingStore.formatNumber(0) : tradingStore.formatSellPrice();
     const rewardForSell = (sellInputStatus == "") ? bnum(0) : tradingStore.rewardForSell;
     let txFailedError = (tradingStore.sellingState == 5) && (sellInputStatus == "") ? true : false;
-    const sellText = datStore.isInitPhase(configStore.activeDatAddress) ? "Withdraw" : "Sell";
+    const sellText = datStore.isInitPhase(configStore.getDXDTokenAddress()) ? "Withdraw" : "Sell";
 
     const checkActive = () => {
         return sellInputStatus === ValidationStatus.VALID;
@@ -110,7 +110,7 @@ const SellInput = observer((props) => {
         if (sellInputStatusFetch === ValidationStatus.VALID) {
             tradingStore.setSellAmount(value);
             const sellReturn = await datStore.fetchSellReturn(
-              configStore.activeDatAddress,
+              configStore.getDXDTokenAddress(),
               denormalizeBalance(value)
             );
             tradingStore.handleSellReturn(sellReturn);
@@ -181,7 +181,7 @@ const SellInput = observer((props) => {
                     // TODO What should last argument be set to?  (the minCurrencyReturned) 
                     datStore
                         .sell(
-                            configStore.activeDatAddress,
+                            configStore.getDXDTokenAddress(),
                             account,
                             denormalizeBalance(str(tradingStore.sellAmount)),
                             bnum(1)

--- a/src/components/Sell/SellSign.js
+++ b/src/components/Sell/SellSign.js
@@ -48,7 +48,7 @@ const SellSign = observer((props) => {
     const price = tradingStore.formatSellPrice();
     const rewardForSell = tradingStore.rewardForSell;
     const sellAmount = tradingStore.formatSellAmount();
-    const sellText = datStore.isInitPhase(configStore.activeDatAddress) ? "Withdraw" : "Sell";
+    const sellText = datStore.isInitPhase(configStore.getDXDTokenAddress()) ? "Withdraw" : "Sell";
 
     const Button = ({ active, children, onClick }) => {
         if (active === true) {

--- a/src/components/Sell/SellUnconfirmed.js
+++ b/src/components/Sell/SellUnconfirmed.js
@@ -47,7 +47,7 @@ const SellUnconfirmed = observer((props) => {
     const price = tradingStore.formatSellPrice();
     const rewardForSell = tradingStore.rewardForSell;
     const sellAmount = tradingStore.formatSellAmount();
-    const sellText = datStore.isInitPhase(configStore.activeDatAddress) ? "Withdraw" : "Sell";
+    const sellText = datStore.isInitPhase(configStore.getDXDTokenAddress()) ? "Withdraw" : "Sell";
 
     const Button = ({ active, children, onClick }) => {
         if (active === true) {

--- a/src/components/WalletModal/index.js
+++ b/src/components/WalletModal/index.js
@@ -316,7 +316,6 @@ const WalletModal = observer(
                     </UpperSection>
                 );
             }
-            console.log(account, walletView === WALLET_VIEWS.ACCOUNT)
             if (account && walletView === WALLET_VIEWS.ACCOUNT) {
                 return (
                     <AccountDetails

--- a/src/components/WalletModal/index.js
+++ b/src/components/WalletModal/index.js
@@ -140,6 +140,7 @@ const WalletModal = observer(
         useEffect(() => {
             if (walletModalOpen) {
                 setPendingError(false);
+                setConnectionErrorMessage(false);
                 setWalletView(WALLET_VIEWS.ACCOUNT);
             }
         }, [walletModalOpen]);

--- a/src/components/WalletModal/index.js
+++ b/src/components/WalletModal/index.js
@@ -128,6 +128,7 @@ const WalletModal = observer(
         const [walletView, setWalletView] = useState(WALLET_VIEWS.ACCOUNT);
         const [pendingWallet, setPendingWallet] = useState();
         const [pendingError, setPendingError] = useState();
+        const [connectionErrorMessage, setConnectionErrorMessage] = useState();
 
         const walletModalOpen = modalStore.walletModalVisible;
 
@@ -147,7 +148,7 @@ const WalletModal = observer(
         const [uri, setUri] = useState()
         useEffect(() => {
           const activateWC = uri => {
-            console.log('uri',uri)
+            console.debug('uri',uri)
             setUri(uri)
             setWalletView(WALLET_VIEWS.PENDING)
           }
@@ -182,7 +183,8 @@ const WalletModal = observer(
             setPendingWallet(connector); // set wallet for pending view
             setWalletView(WALLET_VIEWS.PENDING);
             activate(connector, undefined, true).catch((e) => {
-                console.error('[Activation Error]', e);
+                setConnectionErrorMessage(e)
+                console.debug('[Activation Error]', e);
                 setPendingError(true);
             });
         };
@@ -274,19 +276,19 @@ const WalletModal = observer(
         }
 
         function getModalContent() {
-            if (error) {
+            if (connectionErrorMessage) {
                 return (
                     <UpperSection>
                         <CloseIcon onClick={toggleWalletModal}>
                             <CloseColor alt={'close icon'} />
                         </CloseIcon>
                         <HeaderRow>
-                            {error instanceof UnsupportedChainIdError
+                            {connectionErrorMessage.toString().indexOf('UnsupportedChainIdError') >= 0
                                 ? 'Wrong Network'
                                 : 'Error connecting'}
                         </HeaderRow>
                         <ContentWrapper>
-                            {error instanceof UnsupportedChainIdError ? (
+                            {connectionErrorMessage.toString().indexOf('UnsupportedChainIdError') >= 0 ? (
                                 <h5>
                                     Please connect to the main Ethereum network.
                                 </h5>

--- a/src/components/Web3ReactManager/index.tsx
+++ b/src/components/Web3ReactManager/index.tsx
@@ -31,10 +31,7 @@ const Web3ReactManager = ({ children }) => {
         activate: activateNetwork,
     } = web3ContextBackup;
 
-    providerStore.setWeb3Context(
-        web3ContextNames.injected,
-        web3ContextInjected
-    );
+    providerStore.setWeb3Context(web3ContextNames.injected, web3ContextInjected);
     providerStore.setWeb3Context(web3ContextNames.backup, web3ContextBackup);
 
     const web3React = providerStore.getActiveWeb3React();

--- a/src/provider/connectors.ts
+++ b/src/provider/connectors.ts
@@ -4,9 +4,10 @@ import { InjectedConnector } from '@web3-react/injected-connector'
 import { WalletConnectConnector } from '@web3-react/walletconnect-connector';
 
 export const INFURA_API_KEY = process.env.REACT_APP_KEY_INFURA_API_KEY;
-export const ETH_NETWORK = process.env.REACT_APP_ETH_NETWORK || 'develop';
+export const ETH_NETWORKS = process.env.REACT_APP_ETH_NETWORKS.split(',');
 
-export const chainNameById = {
+
+export const CHAIN_NAME_BY_ID = {
   '1': 'mainnet',
   '3': 'ropsten',
   '4': 'rinkeby',
@@ -14,13 +15,16 @@ export const chainNameById = {
   '66': 'develop',
 };
 
-export const chainIdByName = {
+export const CHAIN_ID_BY_NAME = {
   'mainnet': 1,
   'ropsten': 3,
   'rinkeby': 4,
   'kovan': 42,
   'develop': 66,
 };
+
+export const DEFAULT_ETH_NETWORK = ETH_NETWORKS[0];
+export const DEFAULT_ETH_CHAIN_ID = CHAIN_ID_BY_NAME[ETH_NETWORKS[0]];
 
 export const RPC_URLS = {
   '1': process.env.REACT_APP_SUPPORTED_NETWORK_1 || 'https://mainnet.infura.io/v3/'+INFURA_API_KEY,
@@ -39,32 +43,30 @@ export const web3ContextNames = {
 
 const POLLING_INTERVAL = 5000;
 
-export const supportedChainId = chainIdByName[ETH_NETWORK];
+export const supportedChains = ETH_NETWORKS;
+export const defaultChainId = CHAIN_ID_BY_NAME[ETH_NETWORKS[0]];
+let supportedChainIds = [];
+supportedChains.forEach((network) => supportedChainIds.push(CHAIN_ID_BY_NAME[network]));
 
-export const getSupportedChainName = () => {
-    return ETH_NETWORK;
-};
+// console.log('Supported chains:', supportedChains);
 
 export const isChainIdSupported = (chainId: number): boolean => {
-    return supportedChainId == chainId.toString();
+    return supportedChains.indexOf(CHAIN_NAME_BY_ID[chainId]) >= 0;
 };
 
-const backupUrls = {};
-backupUrls[supportedChainId] = RPC_URLS[supportedChainId];
 export const backup = new NetworkConnector({
-    urls: backupUrls,
-    defaultChainId: supportedChainId,
+    urls: RPC_URLS,
+    defaultChainId: CHAIN_ID_BY_NAME[ETH_NETWORKS[0]],
     pollingInterval: POLLING_INTERVAL,
 });
 
 export const injected = new InjectedConnector({
-    supportedChainIds: [1, 3, 4, 42, 66],
+    supportedChainIds: supportedChainIds,
 });
-
 
 export const walletconnect = new WalletConnectConnector({
   rpc: { 
-    [supportedChainId] : RPC_URLS[supportedChainId.toString()],
+    [defaultChainId] : RPC_URLS[defaultChainId],
   },
   bridge: 'https://bridge.walletconnect.org',
   qrcode: false,

--- a/src/provider/providerHooks.jsx
+++ b/src/provider/providerHooks.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useWeb3React as useWeb3ReactCore } from '@web3-react/core';
 import { isMobile } from 'react-device-detect';
 import { injected, web3ContextNames } from 'provider/connectors';
-import { supportedChainId } from './connectors';
+import { isChainIdSupported } from './connectors';
 
 /*  Attempt to connect to & activate injected connector
     If we're on mobile and have an injected connector, attempt even if not authorized (legacy support)
@@ -13,7 +13,7 @@ export function useActiveWeb3React() {
     const contextInjected = useWeb3ReactCore(web3ContextNames.injected);
 
     return contextInjected.active &&
-        contextInjected.chainId === supportedChainId
+        isChainIdSupported(contextInjected.chainId)
         ? contextInjected
         : contextBackup;
 }

--- a/src/stores/BlockchainFetch.ts
+++ b/src/stores/BlockchainFetch.ts
@@ -1,7 +1,7 @@
 import { action, observable, transaction } from 'mobx';
 import RootStore from 'stores/Root';
 import { Web3ReactContextInterface } from '@web3-react/core/dist/types';
-import { supportedChainId } from '../provider/connectors';
+import { isChainIdSupported } from '../provider/connectors';
 import { validateTokenValue, ValidationStatus } from '../utils/validators';
 import { denormalizeBalance, normalizeBalance } from '../utils/token';
 import { ContractType } from './Provider';
@@ -18,8 +18,9 @@ export default class BlockchainFetchStore {
 
     @action async refreshBuyFormPreview() {
         const { datStore, configStore, tradingStore } = this.rootStore;
+        const activeDATAddress = configStore.getDXDTokenAddress()
         const minValue = normalizeBalance(
-            datStore.getMinInvestment(configStore.activeDatAddress)
+            datStore.getMinInvestment(activeDATAddress)
         );
 
         if (
@@ -30,7 +31,7 @@ export default class BlockchainFetchStore {
             const weiValue = denormalizeBalance(tradingStore.buyAmount);
 
             const buyReturn = await datStore.fetchBuyReturn(
-                configStore.activeDatAddress,
+                activeDATAddress,
                 weiValue
             );
 
@@ -42,7 +43,7 @@ export default class BlockchainFetchStore {
         web3React: Web3ReactContextInterface,
         accountSwitched?: boolean
     ) {
-        if (web3React.active && web3React.chainId === supportedChainId) {
+        if (web3React.active && isChainIdSupported(web3React.chainId)) {
             const { library, account, chainId } = web3React;
             const {
                 providerStore,
@@ -54,6 +55,7 @@ export default class BlockchainFetchStore {
                 transactionStore
             } = this.rootStore;
 
+            const activeDATAddress = configStore.getDXDTokenAddress();
             library.eth
                 .getBlockNumber()
                 .then((blockNumber) => {
@@ -74,6 +76,7 @@ export default class BlockchainFetchStore {
                         console.debug('[Fetch Loop] Fetch Blockchain Data', {
                             blockNumber,
                             account,
+                            chainId
                         });
 
                         // Set block number
@@ -86,7 +89,7 @@ export default class BlockchainFetchStore {
                         // Get global blockchain data
                         multicallService.addCall({
                             contractType: ContractType.ERC20,
-                            address: configStore.activeDatAddress,
+                            address: activeDATAddress,
                             method: 'totalSupply',
                             params: [],
                         });
@@ -104,33 +107,37 @@ export default class BlockchainFetchStore {
 
                             multicallService.addCall({
                                 contractType: ContractType.ERC20,
-                                address: configStore.activeDatAddress,
+                                address: activeDATAddress,
                                 method: 'balanceOf',
                                 params: [account],
                             });
 
                             multicallService.addCall({
                                 contractType: ContractType.ERC20,
-                                address: configStore.activeDatAddress,
+                                address: activeDATAddress,
                                 method: 'allowance',
-                                params: [account, configStore.activeDatAddress],
+                                params: [account, activeDATAddress],
                             });
                         }
 
                         datStore
-                            .fetchRecentTrades(configStore.activeDatAddress, 10)
+                            .fetchRecentTrades(activeDATAddress, 10)
                             .then((trades) => {
                                 tradingStore.setRecentTrades(trades);
+                            })
+                            .catch((e) => {
+                                // TODO: Retry on failure, unless stale.
+                                console.error(e);
                             });
 
                         if (
                             !datStore.areAllStaticParamsLoaded(
-                                configStore.activeDatAddress
+                                activeDATAddress
                             )
                         ) {
                             multicallService.addCalls(
                                 datStore.genStaticParamCalls(
-                                    configStore.activeDatAddress
+                                    activeDATAddress
                                 )
                             );
                         }
@@ -138,7 +145,7 @@ export default class BlockchainFetchStore {
                         const baseDatCall = {
                             contractType:
                                 ContractType.DecentralizedAutonomousTrust,
-                            address: configStore.activeDatAddress,
+                            address: activeDATAddress,
                         };
 
                         multicallService.addCalls([
@@ -174,7 +181,7 @@ export default class BlockchainFetchStore {
                                 );
                                 blockchainStore.updateStore(updates, blockNumber);
 
-                                if (datStore.areAllStaticParamsLoaded(configStore.activeDatAddress)) {
+                                if (datStore.areAllStaticParamsLoaded(activeDATAddress)) {
                                     this.refreshBuyFormPreview();
                                 }
                             })

--- a/src/stores/Provider.ts
+++ b/src/stores/Provider.ts
@@ -4,7 +4,7 @@ import { ethers } from 'ethers';
 import { Web3ReactContextInterface } from '@web3-react/core/dist/types';
 import UncheckedJsonRpcSigner from 'provider/UncheckedJsonRpcSigner';
 import { sendAction } from './actions/actions';
-import { supportedChainId, web3ContextNames } from '../provider/connectors';
+import { isChainIdSupported, web3ContextNames } from '../provider/connectors';
 import PromiEvent from 'promievent';
 import { TXEvents } from '../types';
 import moment from 'moment';
@@ -141,8 +141,8 @@ export default class ProviderStore {
         const contextBackup = this.web3Contexts[web3ContextNames.backup];
         const contextInjected = this.web3Contexts[web3ContextNames.injected];
 
-        return contextInjected.active &&
-            contextInjected.chainId === supportedChainId
+        return contextInjected && contextInjected.active &&
+            isChainIdSupported(contextInjected.chainId)
             ? contextInjected
             : contextBackup;
     }

--- a/src/stores/TradingForm.ts
+++ b/src/stores/TradingForm.ts
@@ -79,7 +79,7 @@ class TradingFormStore {
 
     isDataLoaded(account: string): boolean {
         const {tokenStore, configStore} = this.rootStore;
-        const allowance = tokenStore.getAllowance(configStore.getDXDTokenAddress(), account, configStore.activeDatAddress);
+        const allowance = tokenStore.getAllowance(configStore.getDXDTokenAddress(), account, configStore.getDXDTokenAddress());
         const collateralBalance = tokenStore.getEtherBalance(account);
         const dxdBalance = tokenStore.getBalance(configStore.getDXDTokenAddress(), account);
 

--- a/src/stores/config.ts
+++ b/src/stores/config.ts
@@ -1,11 +1,10 @@
 import RootStore from 'stores/Root';
 import { StringMap } from '../types';
 import { contracts } from '../config/contracts.json';
-import { ETH_NETWORK } from '../provider/connectors';
+import { CHAIN_NAME_BY_ID, DEFAULT_ETH_CHAIN_ID } from '../provider/connectors';
 
 export default class ConfigStore {
     rootStore: RootStore;
-    tokens: StringMap;
     multicall: string;
     activeDatAddress: string;
     network: string;
@@ -13,38 +12,34 @@ export default class ConfigStore {
 
     constructor(rootStore) {
         this.rootStore = rootStore;
-        this.tokens = {} as StringMap;
-        this.parseMetadataFromJson();
+    }
+    
+    getActiveChainName() {
+      const activeWeb3 = this.rootStore.providerStore.getActiveWeb3React();
+      return CHAIN_NAME_BY_ID[(activeWeb3) ? activeWeb3.chainId : DEFAULT_ETH_CHAIN_ID];
     }
     
     getTokenAddress(tokenType) {
-        return this.tokens[tokenType];
+      return contracts[this.getActiveChainName()].DAT;
     }
 
     getMulticallAddress() {
-        return this.multicall;
+      return contracts[this.getActiveChainName()].multicall;
     }
 
     getDXDTokenAddress() {
-        return this.tokens['DXD'];
+      return contracts[this.getActiveChainName()].DAT;
     }
 
     getCollateralTokenAddress() {
-        return this.tokens['Collateral'];
+        return contracts[this.getActiveChainName()].DATinfo.collateralType;
     }
     
     getCollateralType() {
-        return contracts[ETH_NETWORK].DATinfo.collateralType;
+        return contracts[this.getActiveChainName()].DATinfo.collateralType;
     }
     
     getDATinfo() {
-        return contracts[ETH_NETWORK].DATinfo;
-    }
-
-    parseMetadataFromJson() {
-        this.tokens['DXD'] = contracts[ETH_NETWORK].DAT;
-        this.tokens['Collateral'] = contracts[ETH_NETWORK].collateral;
-        this.multicall = contracts[ETH_NETWORK].multicall;
-        this.activeDatAddress = contracts[ETH_NETWORK].DAT;
+        return contracts[this.getActiveChainName()].DATinfo;
     }
 }


### PR DESCRIPTION
Most important changes are in `src/stores/config` and `src/provider/connectors`

- Adds options to support a set of network, the can be mainnet, ropsten, kovan or develop.
- Uses first network in the supported networks array as default network.
- Config Store now gets the address of the DAT contract based on connected network.
- Replaced fetching of active DAT address form config store in the whole app.
- Small changes in scripts to support multiple network configurations.
- Adds .env.example.